### PR TITLE
Missing uppercase & rename title page

### DIFF
--- a/articles/aks/kubernetes-walkthrough-portal.md
+++ b/articles/aks/kubernetes-walkthrough-portal.md
@@ -15,7 +15,7 @@ ms.translationtype: HT
 ms.contentlocale: fr-FR
 ms.lasthandoff: 02/27/2018
 ---
-# <a name="deploy-an-azure-container-service-aks-cluster"></a>Déployer un cluster Azure Container Service (ACS)
+# <a name="deploy-an-azure-container-service-aks-cluster"></a>Déployer un cluster Azure Container Service (AKS)
 
 Dans ce guide de démarrage rapide, vous allez déployer un cluster AKS à l’aide du portail Azure. Une application de plusieurs conteneurs composée d’un serveur web frontal et d’une instance Redis est alors exécutée sur le cluster. Ceci fait, l’application est accessible via internet.
 
@@ -229,7 +229,7 @@ Dans ce guide de démarrage rapide, les images de conteneur, créées au préala
 
 [https://github.com/Azure-Samples/azure-voting-app-redis][azure-vote-app]
 
-## <a name="next-steps"></a>étapes suivantes
+## <a name="next-steps"></a>Étapes suivantes
 
 Dans ce guide de démarrage rapide, vous avez déployé un cluster Kubernetes et vous y avez déployé une application de plusieurs conteneurs.
 


### PR DESCRIPTION
Rename -> Déployer un cluster Azure Container Service (AKS) 
Is not ACS but AKS in this case. 
https://docs.microsoft.com/en-us/azure/aks/intro-kubernetes
Thanks, 
Max.