### PR TITLE
Replace ACS by AKS in index page

### DIFF
--- a/articles/aks/index.yml
+++ b/articles/aks/index.yml
@@ -1,9 +1,9 @@
 ### YamlMime:YamlDocument
 documentType: LandingData
-title: Azure Container Service (ACS)
+title: Azure Container Service (AKS)
 metadata:
   document_id: 
-  title: Documentation Azure Container Service (ACS) - Didacticiels, informations de référence sur les API | Microsoft Docs
+  title: Documentation Azure Container Service (AKS) - Didacticiels, informations de référence sur les API | Microsoft Docs
   meta.description: AKS allows you to quickly deploy a production ready Kubernetes cluster in Azure. Learn how to use AKS with these quickstarts, tutorials, and samples.
   services: container-service
   author: carolz
@@ -20,34 +20,34 @@ metadata:
   ms.contentlocale: fr-FR
   ms.lasthandoff: 04/18/2018
 abstract:
-  description: Azure Container Service (ACS) gère votre environnement Kubernetes hébergé, accélérant et facilitant ainsi le déploiement et la gestion des applications conteneurisées sans expertise d’orchestration de conteneur. Il élimine également la charge des opérations en cours et la maintenance par configuration, la mise à niveau et la mise à l’échelle des ressources à la demande, sans déconnecter vos applications.<div class="IMPORTANT alert"><p>Important</p><p>Azure Container Service (AKS) est actuellement en <strong>préversion</strong>. Les préversions sont à votre disposition, à condition que vous acceptiez les <a href="https://azure.microsoft.com/support/legal/preview-supplemental-terms/">conditions d’utilisation supplémentaires</a>. Certains aspects de cette fonctionnalité sont susceptibles d’être modifiés avant la mise à disposition générale.</p></div>
+  description: Azure Container Service (AKS) gère votre environnement Kubernetes hébergé, accélérant et facilitant ainsi le déploiement et la gestion des applications conteneurisées sans expertise d’orchestration de conteneur. Il élimine également la charge des opérations en cours et la maintenance par configuration, la mise à niveau et la mise à l’échelle des ressources à la demande, sans déconnecter vos applications.<div class="IMPORTANT alert"><p>Important</p><p>Azure Container Service (AKS) est actuellement en <strong>préversion</strong>. Les préversions sont à votre disposition, à condition que vous acceptiez les <a href="https://azure.microsoft.com/support/legal/preview-supplemental-terms/">conditions d’utilisation supplémentaires</a>. Certains aspects de cette fonctionnalité sont susceptibles d’être modifiés avant la mise à disposition générale.</p></div>
 sections:
 - title: Démarrages en 5 minutes
   items:
   - type: paragraph
-    text: 'Découvrez comment déployer un cluster ACS :'
+    text: 'Découvrez comment déployer un cluster AKS :'
   - type: list
     style: icon48
     items:
     - image:
         src: /azure/media/index/ContainerService.svg
-      text: Créer un cluster ACS
+      text: Créer un cluster AKS
       href: /azure/aks/kubernetes-walkthrough
 - title: Didacticiels pas à pas
   items:
   - type: paragraph
-    text: Découvrez comment déployer, gérer et mettre à jour des applications sur un cluster ACS.
+    text: Découvrez comment déployer, gérer et mettre à jour des applications sur un cluster AKS.
   - type: list
     style: ordered
     items:
     - html: <a href="/azure/aks/tutorial-kubernetes-prepare-app">Créer des images de conteneur à partir d’une application</a>
     - html: <a href="/azure/aks/tutorial-kubernetes-prepare-acr">Télécharger des images conteneur dans Azure Container Registry</a>
-    - html: <a href="/azure/aks/tutorial-kubernetes-deploy-cluster">Déployer un cluster ACS</a>
+    - html: <a href="/azure/aks/tutorial-kubernetes-deploy-cluster">Déployer un cluster AKS</a>
     - html: <a href="/azure/aks/tutorial-kubernetes-deploy-application">Exécuter vos images conteneur dans Kubernetes</a>
     - html: <a href="/azure/aks/tutorial-kubernetes-scale">Mettre à l’échelle une application et l’infrastructure Kubernetes</a>
     - html: <a href="/azure/aks/tutorial-kubernetes-app-update">Mettre à jour une application en cours d’exécution dans Kubernetes</a>
     - html: <a href="/azure/aks/tutorial-kubernetes-monitor">Effectuer le monitoring de Kubernetes avec Log Analytics</a>
-    - html: <a href="/azure/aks/tutorial-kubernetes-upgrade-cluster">Mettre à niveau un cluster ACS</a>
+    - html: <a href="/azure/aks/tutorial-kubernetes-upgrade-cluster">Mettre à niveau un cluster AKS</a>
 - title: Informations de référence
   items:
   - type: list


### PR DESCRIPTION
Every article mentions "AKS", but the french index page is still using "ACS".