### PR TITLE
changing Reconnaissance de l’orateur to Speaker recognition

### DIFF
--- a/articles/cognitive-services/Speaker-recognition/Home.md
+++ b/articles/cognitive-services/Speaker-recognition/Home.md
@@ -1,7 +1,7 @@
 ---
-title: Qu’est-ce que l’API Reconnaissance de l’orateur ?
+title: Qu’est-ce que l’API Speaker recognition ?
 titleSuffix: Azure Cognitive Services
-description: Utilisez les algorithmes avancés de vérification de l’orateur et d’identification de l’orateur avec l’API Reconnaissance de l’orateur dans Cognitive Services.
+description: Utilisez les algorithmes avancés de vérification de l’orateur et d’identification de l’orateur avec l’API Speaker recognition dans Cognitive Services.
 services: cognitive-services
 author: dwlin
 manager: nitinme
@@ -18,9 +18,9 @@ ms.contentlocale: fr-FR
 ms.lasthandoff: 08/01/2019
 ms.locfileid: "68707163"
 ---
-# <a name="speaker-recognition-api"></a>API Reconnaissance de l’orateur
+# <a name="speaker-recognition-api"></a>API Speaker recognition
 
-Découvrez les API Reconnaissance de l’orateur d’Azure Cognitive Services. Les API Reconnaissance de l’orateur sont des API basées sur le cloud qui fournissent les algorithmes les plus avancés de vérification de l’orateur et d’identification de l’orateur. Les API Reconnaissance de l’orateur peuvent être divisées en deux catégories : vérification de l’orateur et identification de l’orateur.
+Découvrez les API Speaker recognition d’Azure Cognitive Services. Les API Speaker recognition sont des API basées sur le cloud qui fournissent les algorithmes les plus avancés de vérification de l’orateur et d’identification de l’orateur. Les API Speaker recognition peuvent être divisées en deux catégories : vérification de l’orateur et identification de l’orateur.
 
 
 ## <a name="speaker-verification"></a>Vérification de l’orateur

--- a/articles/cognitive-services/Speaker-recognition/Home.md
+++ b/articles/cognitive-services/Speaker-recognition/Home.md
@@ -1,7 +1,7 @@
 ---
-title: Qu’est-ce que l’API Speaker recognition ?
+title: Qu’est-ce que l’API Speaker Recognition ?
 titleSuffix: Azure Cognitive Services
-description: Utilisez les algorithmes avancés de vérification de l’orateur et d’identification de l’orateur avec l’API Speaker recognition dans Cognitive Services.
+description: Utilisez les algorithmes avancés de vérification de l’orateur et d’identification de l’orateur avec l’API Speaker Recognition dans Cognitive Services.
 services: cognitive-services
 author: dwlin
 manager: nitinme
@@ -18,9 +18,9 @@ ms.contentlocale: fr-FR
 ms.lasthandoff: 08/01/2019
 ms.locfileid: "68707163"
 ---
-# <a name="speaker-recognition-api"></a>API Speaker recognition
+# <a name="speaker-recognition-api"></a>API Speaker Recognition
 
-Découvrez les API Speaker recognition d’Azure Cognitive Services. Les API Speaker recognition sont des API basées sur le cloud qui fournissent les algorithmes les plus avancés de vérification de l’orateur et d’identification de l’orateur. Les API Speaker recognition peuvent être divisées en deux catégories : vérification de l’orateur et identification de l’orateur.
+Découvrez les API Speaker Recognition d’Azure Cognitive Services. Les API Speaker Recognition sont des API basées sur le cloud qui fournissent les algorithmes les plus avancés de vérification de l’orateur et d’identification de l’orateur. Les API Speaker Recognition peuvent être divisées en deux catégories : vérification de l’orateur et identification de l’orateur.
 
 
 ## <a name="speaker-verification"></a>Vérification de l’orateur


### PR DESCRIPTION
Changing Reconnaissance de l'orateur to Speaker recognition because it's the real name of the service and it's doesn't needed to be translated.

Informations utiles pour faire une suggestion :
1. Accédez à [Guides de style de localisation Démarrage rapide](https://docs.microsoft.com/globalization/localization/styleguides) pour consulter les **10 règles les plus importantes** du guide de style Microsoft.
2. Accédez au [Portail linguistique de Microsoft](https://www.Microsoft.com/Language) pour vérifier la **traduction standard d'un terme** dans les produits Microsoft.
