### PR TITLE
Update apache-spark-secure-credentials-with-tokenlibrary.md

### DIFF
--- a/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
+++ b/articles/synapse-analytics/spark/apache-spark-secure-credentials-with-tokenlibrary.md
@@ -351,7 +351,7 @@ print(connection_string)
 ```csharp
 using Microsoft.Spark.Extensions.Azure.Synapse.Analytics.Utils;
 
-string connectionString = TokenLibrary.getSecret("<AZURE KEY VAULT NAME>", "<SECRET KEY>", "<LINKED SERVICE NAME>");
+string connectionString = TokenLibrary.GetSecret("<AZURE KEY VAULT NAME>", "<SECRET KEY>", "<LINKED SERVICE NAME>");
 Console.WriteLine(connectionString);
 ```
 


### PR DESCRIPTION
In the C# lib, 'getSecret' method does not exist, the 'GetSecret' with a capital 'G' does though... If you use the 'getSecret' method, you'll get a 'TokenLibrary does not contain a definition for  'getSecret' ' error. Haven't checked the other languages...
